### PR TITLE
fix(wildcard): added `''` to avoid wildcards 🐛

### DIFF
--- a/lua/link-visitor/utils.lua
+++ b/lua/link-visitor/utils.lua
@@ -125,7 +125,7 @@ end
 ---@param link Link
 function M.visit(link)
 	if confirm("Visit " .. link.link .. " ?") then
-		fn.jobstart(string.format("%s %s", config.open_cmd, link.link), {
+		fn.jobstart(string.format("%s '%s'", config.open_cmd, link.link), {
 			on_stderr = function(_, data)
 				local msg = table.concat(data or {}, "\n")
 				if msg ~= "" then


### PR DESCRIPTION
Without this fix I cannot open links with query parameters such as `?id=5`.

I do not own a windows nor mac computer so I cannot test that it still works on those, but I imagine the syntax will be the same.

Hope this can be implemented or you can help me fix this issue in my shell :)

I dont know if its just fish shell that uses `?` as a wildcard symbol, though.

Anyway, love the plugin <3

Thanks for your time.